### PR TITLE
add user session controller and user model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'jquery-rails'
 gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
-gem 'devise'
+gem 'monban'
+gem 'monban-generators'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,13 +59,6 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.0)
     debug_inspector (0.0.2)
-    devise (3.5.6)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
-      responders
-      thread_safe (~> 0.1)
-      warden (~> 1.2.3)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -87,10 +80,15 @@ GEM
     mime-types (2.99)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
+    monban (0.2.1)
+      bcrypt
+      rails
+      warden
+    monban-generators (0.0.4)
+      monban (>= 0.0.12)
     multi_json (1.11.2)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
-    orm_adapter (0.5.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -121,8 +119,6 @@ GEM
     rake (10.5.0)
     rdoc (4.2.2)
       json (~> 1.4)
-    responders (2.1.1)
-      railties (>= 4.2.0, < 5.1)
     rspec-core (3.4.2)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -186,9 +182,10 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
-  devise
   jbuilder (~> 2.0)
   jquery-rails
+  monban
+  monban-generators
   rails (= 4.2.5.1)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include Monban::ControllerHelpers
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,28 @@
+class SessionsController < ApplicationController
+  skip_before_action :require_login, only: [:new, :create]
+
+  def new
+  end
+
+  def create
+    user = authenticate_session(session_params)
+
+    if sign_in(user)
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    sign_out
+    redirect_to root_path
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
+  end
+end
+

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,25 @@
+class UsersController < ApplicationController
+  skip_before_action :require_login, only: [:new, :create]
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = sign_up(user_params)
+
+    if @user.valid?
+      sign_in(@user)
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password)
+  end
+end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ActiveRecord::Base
+  validates :email, presence: true, uniqueness: true
+  validates :password_digest, presence: true
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,13 @@
+<%= form_for :session, url: session_path do |form| %>
+  <div>
+    <%= form.label :email %>
+    <%= form.email_field :email %>
+  </div>
+  <div>
+    <%= form.label :password %>
+    <%= form.password_field :password %>
+  </div>
+  <div>
+    <%= form.submit "Sign in" %>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,23 @@
+<%= form_for @user do |form| %>
+
+  <% if @user.errors.any? %>
+    <%= pluralize(@user.errors.count, "error") %> prevented your account from being created:
+    <ul>
+      <% @user.errors.full_messages.each do |error_message| %>
+        <li><%= error_message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <div>
+    <%= form.label :email %>
+    <%= form.email_field :email %>
+  </div>
+  <div>
+    <%= form.label :password %>
+    <%= form.password_field :password %>
+  </div>
+  <div>
+    <%= form.submit "Sign up" %>
+  </div>
+<% end %>

--- a/config/locales/monban.en.yml
+++ b/config/locales/monban.en.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      user:
+        password_digest: "Password"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  resource :session, only: [:new, :create, :destroy]
+  resources :users, only: [:new, :create]
+  resource :session, only: [:new, :create, :destroy]
+  resources :users, only: [:new, :create]
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20160211203607_create_users.rb
+++ b/db/migrate/20160211203607_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.string :email, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20160211203607) do
+
+  create_table "users", force: :cascade do |t|
+    t.string   "email",           null: false
+    t.string   "password_digest", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+
+end


### PR DESCRIPTION
# Description
- fixes #9 and fixes #10 
- added `user` model
- generated migration
- contains `email` and `password` field for now to support authentication
- also adds the Monban gem to handle user session management and authentication
# Steps to :tophat: (or `tophat` means to pull down the branch onto your local and  throughly testing out all the features)
- pull this branch onto local machine
- `rake db:migrate` to run migrations and update your local database copy
- jump into the rails console (this is new) with `rails c --sandbox`
- notice I prepended the command with the `--sandbox` argument. This essentially reverts back all your changes once you exit the console. It's a good practise since you can play around with the models without breaking anything!
- to create a new `user` type `user = User.new(email: 'example@email.com', password_digest: 'somePassword')`
- save the user `user.save` ( this should return `=> true`)
- you can do the above two steps (creating and saving) in one go with `User.create(email: 'example@email.com', password_digest: 'somePassword')`
- additionally verify that duplicate users cannot be created and
- `email` &&/|| `password_digest` cannot be empty
# Reviewers

@mrajendr @sujan-sube 
