### PR TITLE
add rails panel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,6 @@ end
 group :development do
   gem 'web-console', '~> 2.0'
   gem 'spring'
+  gem 'meta_request'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.2)
     byebug (8.2.2)
+    callsite (0.0.11)
     capybara (2.6.2)
       addressable
       mime-types (>= 1.16)
@@ -73,6 +74,7 @@ GEM
     factory_girl_rails (4.6.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    git-version-bump (0.15.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -88,6 +90,10 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    meta_request (0.4.0)
+      callsite (~> 0.0, >= 0.0.11)
+      rack-contrib (~> 1.1)
+      railties (>= 3.0.0, < 5.1.0)
     mime-types (2.99)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -101,6 +107,9 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     rack (1.6.4)
+    rack-contrib (1.4.0)
+      git-version-bump (~> 0.15)
+      rack (~> 1.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.5.1)
@@ -197,6 +206,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   jbuilder (~> 2.0)
   jquery-rails
+  meta_request
   monban
   monban-generators
   rails (= 4.2.5.1)


### PR DESCRIPTION
- fixes #46 
- this is great for faster debugging!
- it adds a `Rails` panel inside the chrome developer console and allows you to see stuff like which routes is being hit, which controller-action is responding to the request and even the data inside that params!
- **_Note**_: you will need to install the chrome extension from [here](https://chrome.google.com/webstore/detail/railspanel/gjpfobpafnhjhbajcjgccbbdofdckggg)
- more info [here](https://github.com/dejan/rails_panel)

@matraj @sujan-sube 
